### PR TITLE
changed targetSdkVersion & compileSdkVersion to 31

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -13,12 +13,12 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 30
+    compileSdkVersion 31
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 30
+        targetSdkVersion 31
         versionCode 1
         versionName "1.0"
     }


### PR DESCRIPTION
This commit is intended to change fix a build error on RN 0.70.0-rc.3. The current build error is 

> FAILURE: Build completed with 2 failures.
node_modules/react-native-a-beep/android/build/intermediates/merged_res/release/values/values.xml:2722: AAPT: error: resource android:attr/lStar not found.